### PR TITLE
Added opt out option on token config

### DIFF
--- a/module.js
+++ b/module.js
@@ -188,13 +188,19 @@ const TokenFactions = (() => {
       const drawFrameOverride = flags ? flags['draw-frame'] : undefined;
       const drawFrame = drawFrameOverride === undefined ? drawFramesByDefault : drawFrameOverride;
       const checked = drawFrame ? ' checked="checked"' : '';
-
+      const skipDraw = flags ? flags['disable'] : undefined;
+      const isDisabled = skipDraw ? ' checked="checked"' : '';
       html.find('input[name="mirrorY"]').parent().after(`\
+      <div class="form-group">
+        <label>Disable Faction Disposition Visualization</label>
+        <input type="checkbox" name="flags.${MODULE}.disable" data-dtype="Boolean"${isDisabled}>
+      </div>
         <div class="form-group">
           <label>Overlay A Faction-Based Frame</label>
           <input type="checkbox" name="flags.${MODULE}.draw-frame" data-dtype="Boolean"${checked}>
         </div>`);
     }
+    
 
     static async updateTokens(tokenData) {
       let tokens = canvas.tokens.placeables;
@@ -221,6 +227,9 @@ const TokenFactions = (() => {
     static updateTokenBase(token) {
       if ((token instanceof Token) && token.icon && bevelTexture && bevelTexture.baseTexture) {
         const flags = token.data.flags[MODULE];
+        const skipDraw = flags ? flags['disable'] : undefined;
+        if(skipDraw)
+          return;
         const drawFramesByDefault = game.settings.get(MODULE, 'draw-frames-by-default');
         const drawFrameOverride = flags ? flags['draw-frame'] : undefined;
         const drawFrame = drawFrameOverride === undefined ? drawFramesByDefault : drawFrameOverride;


### PR DESCRIPTION
I added a checkbox on token config to opt that token out of any kind of token disposition drawing.  This is useful for tokens like hazards and others that don't have a frame at all.